### PR TITLE
Re-number the protocol versions to reflect the "Beta Stage" of the Maste...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Mastercoin Complete Specification
 Version 0.3.5 (Class C Data Storage Method "Proveably Prune-able Outputs" Edition)
 
 dacoinminster (j DOT r DOT willett AT gmail.com)
-
-The Mastercoin Foundation - info@mastercoin.org
+petertodd (https://github.com/petertodd)
+DavidJohnstonCEO (https://github.com/DavidJohnstonCEO)
+ripper234 (https://github.com/ripper234?source=c)
 
 # Summary
 


### PR DESCRIPTION
...rcoin Specification / Implementations

It seems logical to inform new comers that the Mastercoin Protocol is currently in the Beta stage of its development. I propose we can easily accomplish this by simply re-numbering the versions of the protocol (both past and present) to version numbers below that of 1.0

For example version 0.1 version 0.19 and version 0.2 for past versions and 0.3 for the current version. This gives the protocol enough room for growth between now and when it does reach a 1.0 stage of development.
