### PR TITLE
Re-number the protocol versions to reflect the "Beta Stage" Try #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Note that all transfers of value are still stored in the normal bitcoin block ch
 
 # Document History
 
-* 1. Version 0.1 (previously 0.5) released 1/6/2012 (No packet definitions, overly-complicated currency stabilization)
-* 2. Version 0.1.9 (previously 0.7) released 7/29/2013 (Preview of 0.2, but without revealing the Exodus Address)
-* 3. Version 0.2 (previously 1.0) released 7/31/2013 (Version used during the fund-raiser)
-* 4. Version 0.3 (previously 1.1) released 9/9/2013 (Smart Property + improvements for easier parsing & better escrow fund health)
-* 5. Version 0.3.5 (previously 1.2) released 11/11/2013 (Added "Pay Dividend" message, spending limits for savings wallets, contract-for-difference bets, and distributed e-commerce messages. Also added Zathras' new appendix (description of class B and class C methods of storing Mastercoin data).
+1. Version 0.1 (previously 0.5) released 1/6/2012 (No packet definitions, overly-complicated currency stabilization)
+2. Version 0.1.9 (previously 0.7) released 7/29/2013 (Preview of 0.2, but without revealing the Exodus Address)
+3. Version 0.2 (previously 1.0) released 7/31/2013 (Version used during the fund-raiser)
+4. Version 0.3 (previously 1.1) released 9/9/2013 (Smart Property + improvements for easier parsing & better escrow fund health)
+5. Version 0.3.5 (previously 1.2) released 11/11/2013 (Added "Pay Dividend" message, spending limits for savings wallets, contract-for-difference bets, and distributed e-commerce messages. Also added Zathras' new appendix (description of class B and class C methods of storing Mastercoin data).
 
 * Pre-github versions of this document (prior to version 0.3.5 / previously 1.2) can be found at https://sites.google.com/site/2ndbtcwpaper/
 


### PR DESCRIPTION
_This 2nd try includes grammar fixes and input from J.R. on references to old numbering system_

It seems logical to inform new comers that the Mastercoin Protocol is currently in the Beta stage of its development. I propose we can easily accomplish this by simply re-numbering the versions of the protocol (both past and present) to version numbers below that of 1.0
For example version 0.1 version 0.19 and version 0.2 for past versions and 0.3 for the current version. This gives the protocol enough room for growth between now and when it does reach a 1.0 stage of development.
