### PR TITLE
Using the term "Master Protocol"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Master Protocol / Mastercoin Complete Specification
 
 Version 0.3.5 (previously version 1.2) Class C Data Storage Method "Provably Prune-able Outputs" Edition
 
-* JR Willett dacoinminster (https://github.com/dacoinminster and jr DOT willett AT gmail DOT com)
+* JR Willett (https://github.com/dacoinminster and jr DOT willett AT gmail DOT com)
 * Peter Todd (https://github.com/petertodd)
 * Maran Hidskes (https://github.com/maran)
 * David Johnston (https://github.com/DavidJohnstonCEO)


### PR DESCRIPTION
I'd like to make a proposal to you my friends. Lets begin talking about the "Master Protocol" and "Mastercoins" separately, preferring first to explain the Master Protocol to the public / new users. "Bitcoin" (the protocol / network) and "bitcoins" the digital currency has the same issue and I see from the updates to the Bitcoin wikipedia article they are getting better at explaining the difference between the two right up front. "Bitcoin is a peer-to-peer payment network and digital currency with a public transaction log". The other confusion this avoids is that of existing Bitcoiners thinking the Master Protocol / Mastercoin is an "Alt-Coin", by which most people mean either that it has its own "alternative" blockchain or that it is an "alternative" competitor to Bitcoin. Neither of these assumptions is correct in the case of the Master Protocol / Mastercoin project. Thus if we want to save ourselves many hours of explaining this project isn't an "Alt-Coin", I humbly suggest we stop introducing it with a term that has "coin" in it and instead start by explaining the cool "Master Protocol" features and then explain that it works on top of the Bitcoin Protocol and even has a "digital token" for users to access these cool features.

I also fixed some inaccurate language in the legal section.
