### PR TITLE
Increase spending limits

### DIFF
--- a/VotingRules.md
+++ b/VotingRules.md
@@ -1,11 +1,11 @@
 ## One time expenses ##
-1. 1 Board member may spend up to $100 without consulting anybody
-2. 2 Board members may agree to spend up to $500, as long as there are no objections raised
-3. 3 Board members may agree to spend up to $1000, as long as there are no objections raised
-4. 4 Board members may agree to spend up to $2000, as long as there are no objections raised
-5. 5 Board members may agree to spend up to $5000, as long as there are no objections raised
-6. 6 Board members may agree to spend up to $20000, as long as there are no objections raised
-7. The board must vote unanimously to spend more than $20000
+1. 1 Board member may spend up to $500 without consulting anybody
+2. 2 Board members may agree to spend up to $1000, as long as there are no objections raised
+3. 3 Board members may agree to spend up to $2500, as long as there are no objections raised
+4. 4 Board members may agree to spend up to $5000, as long as there are no objections raised
+5. 5 Board members may agree to spend up to $10000, as long as there are no objections raised
+6. 6 Board members may agree to spend up to $25000, as long as there are no objections raised
+7. The board must vote unanimously to spend more than $25000
 
 ## Discretionary Funds ##
 The board may approve a member (such as the Executive Director) to have a larger pool of discretionary funds by unanimous vote


### PR DESCRIPTION
I think the current spending limits are too low, they are triggering board votes which take time and slow us down.

These are the new limits that I propose:
1. 1 Board member may spend up to $500 without consulting anybody
2. 2 Board members may agree to spend up to $1000, as long as there are no objections raised
3. 3 Board members may agree to spend up to $2500, as long as there are no objections raised
4. 4 Board members may agree to spend up to $5000, as long as there are no objections raised
5. 5 Board members may agree to spend up to $10000, as long as there are no objections raised
6. 6 Board members may agree to spend up to $25000, as long as there are no objections raised
7. The board must vote unanimously to spend more than $25000
