### PR TITLE
Class A Rule Simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ The transaction data is encoded into said fake Bitcoin address which is then use
 
 NOTE: The sequence number for a given address is defined as a 1 -byte integer stored as the first byte of each 'packet'.   Sequence numbers are continuous with 0 following 255 (256=0, 255+1=0). 
 
-NOTE: Should a transaction result in an edge case that appears to follow the rules above but fails to exclusively and without ambiguity identify the sending, reference and data addresses the transaction is considered invalid.
+NOTE: Should a transaction result in an edge case that provides conflicting reference address values for sequence numbers and equal outputs, the reference address identified via equal outputs will take precedence.
 
 As there is no private key associated with these fake addresses they are inherently unspendable.  This creates concerns around blockchain bloat, especially within the UTXO (Unspent Transaction Output) set as each use of a fake address adds an unspent output to the UTXO dataset that will never be redeemed, thus growing (or ‘bloating’) it. 
 


### PR DESCRIPTION
Class A is only intended to provide backwards compatibility & is not used in any of the respective wallet implementations or for any features other than basic simple send.  Thus the effort being expended on Class A does not correlate with its utility to the project and this pull is intended to put Class A to bed so we can move onto other more useful work.

As discussed with Tachikoma.  Further details please see https://bitcointalk.org/index.php?topic=292628.msg4499342#msg4499342
