### PR TITLE
Adding separate message to cancel an existing Selling Offer. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,10 @@ The amount for sale will be reserved from the actual balance for this address mu
 
 ## Cancelling an Offer
 
-If you decide you want to cancel an offer, simply re-send the offer, but enter the number of coins for sale as zero.
+Cancelling an existing offer would takes 8 bytes.
+
+1. Transaction type = 23 for cancelling existing trade offer (32-bit unsigned integer, 4 bytes)
+2. Currency identifier for sale = 1 for Mastercoin (32-bit unsigned integer, 4 bytes)
 
 ## Changing an Offer
 


### PR DESCRIPTION
A variation of #39 where we use a separate message to cancel an order instead of re-using the Selling Offer. 

I think it makes more sense to officially cancel an order, I understand that broadcasting a new Selling Offer with a zero amount makes it clear enough that there is nothing for sale yet but it still feels ugly. Any implementation that wants to show Selling Offers needs to create custom logic to deal with Selling Offers with zero amounts.

This is mostly just to gauge interest in this one and see if anybody feels the same way about this. 
