### PR TITLE
Safer currency/property identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ This section defines the fields that are used to construct transaction messages.
 ### Field: Currency identifier
 + Description: the currency used in the transaction
 + Size: two 32-bit unsigned integers (4 bytes each) or 1 such integer in special cases
-+ Valid values: these form a reference to the transaction in which the currency was created. The first integer is the number of the block in the blockchain and the second is the byte offset within the block of that transaction. Since no currencies were created before block 131072, any block numbers below 131072 can be considered as special values, e.g. "1" for MasterCoin.
++ Valid values: these form a reference to the transaction in which the currency was created. The first integer is the number of the block in the blockchain and the second is the byte offset within the block of that transaction. Since no currencies were created before block 131072, any block numbers below 131072 can be considered as special values, e.g. "1" for MasterCoin. For these special currencies, the byte offset can be skipped.
 
 ### Field: Integer-eight byte
 + Description: used as a multiplier or in other calculations


### PR DESCRIPTION
I am proposing a different way of referring to user-created currencies or properties. My reasoning is as follows:
- Enumerating in ascending order feels dangerous because some small differences in MasterCoin implementations (e.g. in dealing with slightly misformatted smart property creation transactions) will lead to two parties having a completely different opinion about the meaning of _every single_ currency identifier after the ambiguous transaction. By pointing directly to the transaction which created the currency or smart property, the damage created by such differences of opinion will be limited in scope.
- A MasterCoin-compatible client or wallet should be able to retrieve the transaction that created the currency/property of interest within having to download and process the entire blockchain. By giving a block number and byte offset, this becomes easy to do, since the block can be retrieved from the bitcoin network using only its hash.

I have many other suggestions about how to improve this further, such as:
- Adding a short hash of the transaction ID in which the currency was created, in order to ensure that blockchain substitutions don't lead to multiple possible interpretations of the same currency identifier.
- For now a 24-bit integer will be enough for both the block number and transaction index, but we want to be future-proof, so we must permit 32-bit integers as well. So a metadata byte could be used to define the packing of these integers (and many other things relating to the send transaction, such as quantity). This metadata byte will enable a _lot_ of space to be saved, e.g. allowing an 8-bit integer to be used for the quantity where possible. Or even no integer at all, if the quantity is 1.

Thanks for your consideration.
