### PR TITLE
Add transaction type Multi Send

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ A Multi send to a non-existent address will destroy the coins in question, just 
 
 [Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
 
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
+Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only 12 bytes are needed. The data stored is:
 
 1. [Transaction version](#field-transaction-version) = 0
 1. [Transaction type](#field-transaction-type) = 5


### PR DESCRIPTION
This pull request proposes a method of sending one or more types of coins to one more more recipients. The data footprint of an additional send can be reduced to a single byte of the data output.

I'm expecting that the manner in which I've proposed calculating the value will be controversial, given that more resolution costs more money. But under most circumstances, 3/4 magnitudes from the most significant digit is acceptable, especially considering that the smaller units of a given coin represent negligible values.

I've also added a boolean array datatype, to allow true/false flags without representing them as integers and identifying all possible combinations. There are one or two places there this could be used at the present I believe (though probably not worth the effort).

@gidgreen This is very relevant to the following multiple send pull request which seems to have lost some steam: https://github.com/mastercoin-MSC/spec/pull/54

It also sets the stage to allow multiple inputs and multiple outputs (trivial in fact, just add input references): https://github.com/mastercoin-MSC/spec/issues/77

Given a person may be required to send to multiple recipients, the cost of transactions is also addressed: https://github.com/mastercoin-MSC/spec/issues/192
