### PR TITLE
Add Appendix F - Concerning the Proposal for the Output Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ A Multi send to a non-existent address will destroy the coins in question, just 
 
 [Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
 
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only 12 bytes are needed. The data stored is:
+Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
 
 1. [Transaction version](#field-transaction-version) = 0
 1. [Transaction type](#field-transaction-type) = 5

--- a/README.md
+++ b/README.md
@@ -1322,3 +1322,14 @@ The transition to an output model and removal of the requirement that Master Pro
 - Eliminates controversial "tax" to the Exodus address.
 - Decreases data footprint of Master Protocol transactions.
 - Decreases total cost of Master Protocol transactions.
+
+### Optimizing the Cost of Master Protocol Messages
+
+The output model's transparent support of P2SH inputs and outputs enables a method of Master Protocol transaction construction that:
+
+- Eliminates the required output to the Exodus address (0.00006 BTC).
+- Eliminates the required output to a multisig output (0.00012 BTC).
+- Eliminates potential blockchain bloat.
+- Reduces the cost of a Master Protocol transaction to the smallest value that one can expect to pay for *any* Bitcoin transaction (0.00016 BTC)
+
+This is accomplished by using the intended recipient's public key as the 1-of-n public keys in a P2SH redeem script. By using the other public keys in the redeem script to encode Master Protocol data, the same as Class B transactions, we can reduce Master Protocol transactions to requiring only a single transaction output, and reduce the cost of transactions by nearly 53% (from 0.00034 BTC with Class B transactions to 0.00016 BTC).

--- a/README.md
+++ b/README.md
@@ -1250,6 +1250,23 @@ If Bob finds that the transaction satisfies the requirements of the trade he can
 
 In this manner we can guarantee that both traders receive the Master Protocol tokens without requiring trust. In the scenario that Alice refrains from signing the transaction, Bob still maintains control of his LOLcoins. While this method requires an additional transaction compared to trades with Bitcoin, it's still preferable to the previous methods - and it should be noted that the traders need not wait for the first transaction to be confirmed before broadcasting the second.
 
+A more detailed example follows:
+
+1. Alice broadcasts a transaction tx_offer with the offer to trade Mastercoins for LOLcoins, where the UXTO representing the Mastercoins is spendable by the private key privKey_a0 with the public key pubKey_a0.
+2. Bob wishes to fill the offer defined by tx_offer. He generates private key privKey_b0 with the associated public key pubKey_b0 and private key privKey_b1 with the associated public key pubKey_b1.
+3. Bob crafts, signs, and broadcasts a transaction tx_accept as follows:
+    * Input 0: A UXTO that represents a quantity of LOLcoins
+    * Output 0: 2-of-3 multisig output, where the public keys are pubKey_a0, pubKey_b0, and pubKey_b1.
+    * Output 1: Data output
+4. Alice sees the transaction tx_accept and crafts a transaction tx_final as follows:
+    * Input 0: UXTO at index 0 from the transaction tx_accept
+    * Input 1: UXTO that represents Mastercoins from the transaction tx_offer
+    * Output 0: pubKey_a0, to which Alice will receive LOLcoins
+    * Output 1: pubKey_b0, to which Bob will receive Mastercoins
+    * Output 2: Data output
+5. Alice signs the inputs at indices 0 and 1 from the transaction tx_final with the private key privKey_a0 and then sends the incomplete transaction to Bob.
+6. Bob verifies that the transaction tx_final is acceptable and adds his signature to the input at index 0 with the private key privKey_b0. He then broadcasts the transaction to the Bitcoin network to finalize the trade.
+
 ### Cross Protocol Atomic Meta DEx
 
 Master Protocol's transition to an output model allows the ability to perform trustless atomic trades of Mastercoins for tokens on various other protocols and platforms. This currently applies to colored coin implementations, however the Master Protocol transparently supports atomic trades with any future protocol that can represent an asset with a single UXTO.

--- a/README.md
+++ b/README.md
@@ -1189,3 +1189,105 @@ As we can see from the above, the true cost of a Master Protocol message may be 
 A further consideration relates to how multisig outputs are presented in the bitcoin reference client.  It is technically accurate to state that any of the addresses within a Class B multisig output can redeem, however only one of these addresses (the sending address) actually has a known private key.  The bitcoin reference client however of course has no way of knowing this and so does not include unspent multisig outputs in the displayed balance.  
 
 It is envisaged that in future Master Protocol clients will 'clean up' periodically by redeeming and consolidating unspent multisig outputs.
+
+# Appendix F - Details on the Proposal to Transition to an Output Model
+
+Issue https://github.com/mastercoin-MSC/spec/issues/189 discusses the question, "Should we migrate to an output model rather than a address model?" The idea behind the question is that the Master Protocol, since its inception, has associated balances of Master Protocol tokens with Bitcoin addresses. While there is nothing inherently wrong with this it has many implications that concern how the protocol is implemented, what the protocol can do, and how secure its transactions can be. With the consideration that Bitcoin associates balances with UXTOs (unspent transaction outputs), the association of balances with addresses is an unprecedented and novel concept.
+
+With that said, the proposal to transition to an output model also describes an unprecedented and novel concept. This appendix details specifics about the proposal to transition the Master Protocol to an output model, and explores the implications of the transition away from the address model.
+
+## The Output Transaction Model
+
+The transaction model for all Master Protocol tokens that are associated with transaction outputs can be generalized by the following rules of interpretation:
+
+- A transaction consumes the tokens represented by the input.
+- A transaction will send all tokens to the last output, unless otherwise specified by a data output.
+
+If we spend an output that represents a quantity of tokens in a normal Bitcoin transaction, the tokens will typically be returned to the sender at a change address. By carefully crafting transactions, we can guarantee that an invalid Master Protocol transaction will return all tokens to the sender. This basic mechanism of token transfer allows the Master Protocol to stay in line with Bitcoin best practices by not reusing addresses.
+
+## Transaction Definitions
+
+This section may appear sparse in comparison to the section titled the same in the main Master Protocol specification. It should be understood that this isn't necessarily due to a decrease in functionality. In some circumstances a function that previously required a transaction type to be defined can be implicitly performed without a specific Master Protocol definition.
+
+### Output Transition
+
+Description: Transaction type yyy that will convert Master Protocol tokens to be associated with a Bitcoin transaction output rather than a Bitcoin address. This transaction type is irreversible.
+
+* All tokens of specified currency identifier in the data output are henceforth attached to the output that is sent to the reference address.
+* The data output will include the currently valid chain of ownership from the Exodus address all the way to the current transaction in the form of a merkle tree of transaction hashes concatenated with current balance.
+
+Say you want to convert Mastercoin. Only 8 bytes are needed. The data stored is:
+
+1. [Transaction version](#field-transaction-version) = 0
+1. [Transaction type](#field-transaction-type) = yyy
+1. [Currency identifier](#field-currency-identifier) = 1 for Mastercoin 
+
+## Distributed Exchange
+
+As a core function of the Master Protocol, the distributed exchange (DEx) boasts the largest improvements by the transition to an output model over the address model implementations. The specifics are discussed in detail below as they are relevant to the sub-section - however a few items are relevant to all output model DEx functions:
+
+- Instantaneous and trustless trading, regardless of what is being traded.
+- Reduce complexity in implementation by tracking transaction outputs rather than the resolution of matching buy/sell orders.
+- Eliminate circumstances in which Bitcoin payment is confirmed after block deadline.
+
+### Atomic DEx
+
+Master Protocol tokens can quickly and safely be traded for bitcoins through the utilization of atomic trades, provided that the tokens are of the output model. The main advantage over the previous methods is the amount of time that a trade takes. Previously a trade could only be finalized after 3 distinct Master Protocol transactions had been confirmed in the blockchain.
+
+The atomic DEx allows traders to instantaneously trade Master Protocol tokens for bitcoins and the tokens may immediately be treated as if they were bitcoin i.e. an unconfirmed Master Protocol token output may be treated the same as an unconfirmed bitcoin output.
+
+The atomic DEx does not require any specific Master Protocol transactions due to the nature of the output model. Not only does this simplify the Master Protocol specification, but it reduces the cost of trading for its users.
+
+### Atomic Meta DEx
+
+The atomic meta DEx is a technical addition to the atomic DEx that allows any Master Protocol token to be traded for any other Master Protocol token. The atomic meta DEx should be considered when trading Master Protocol tokens that are unique, represent physical goods, or are not universally considered valuable.
+
+If Bob wishes to accept Alice's offer to trade 1 Mastercoins for 1000 LOLcoins, Bob can create a transaction that enables an atomic swap. This transaction should send 1000 LOLcoins to a multisignature output that requires 2-of-3 signatures in order to spend. The first and second signatures should belong to Bob while the third belongs to Alice.
+
+Once the unsigned transaction is created, Bob sends it to Alice who adds an input with the required 1 Mastercoin and signs it with her private keys as necessary. Since Alice could only sign 1 of the required 2 signatures required to spend the multisignature output, she must send the transaction back to Bob to complete.
+
+If Bob finds that the transaction satisfies the requirements of the trade he can add the second signature that is required to spend the multisignature output, and finally broadcast the transaction.
+
+In this manner we can guarantee that both traders receive the Master Protocol tokens without requiring trust. In the scenario that Alice refrains from signing the transaction, Bob still maintains control of his LOLcoins. While this method requires an additional transaction compared to trades with Bitcoin, it's still preferable to the previous methods - and it should be noted that the traders need not wait for the first transaction to be confirmed before broadcasting the second.
+
+### Cross Protocol Atomic Meta DEx
+
+Master Protocol's transition to an output model allows the ability to perform trustless atomic trades of Mastercoins for tokens on various other protocols and platforms. This currently applies to colored coin implementations, however the Master Protocol transparently supports atomic trades with any future protocol that can represent an asset with a single UXTO.
+
+This groundbreaking interoperability sets the stage for Mastercoins and the Master Protocol to become a centerpiece in the Bitcoin 2.0 space by bridging numerous implementations and providing a liquidity layer for assets that may not otherwise acheive the exposure necessary to succeed.
+
+## Smart Property
+
+### Atomic Crowdsale
+
+https://github.com/mastercoin-MSC/spec/issues/189#issuecomment-50251410
+
+### Atomic Meta Crowdsale
+
+Just as Master Protocol tokens can be traded for other Master Protocol tokens on the DEx by utilizing a multisignature output, the same idea can be applied to the atomic crowdsale to allow payment from currencies other than Bitcoin.
+
+### Concerning the Use of Mastercoin in an Output Model
+
+The transition of the Master Protocol to an output model can make the specific uses of Mastercoin unclear. Despite the fact that the Mastercoin token is not inherently different than any other Master Protocol token, it is unique in that it is the only fundamental and universal Master Protocol token. With this in consideration, it's reasonable to leverage the fundamental and universal properties of Mastercoin to create a liquidity layer which we can count on to enable the advanced features of the Master Protocol.
+
+- Only Mastercoins will be supported for the Send to Owners transaction type.
+- Only Mastercoins will be burned where anti-spam fees are required.
+- Only Mastercoins will be used in escrow applications.
+- Only Mastercoins will be supported in Savings and Rate-Limited transaction types.
+- Only Mastercoins will be supported for cross protocol atomic transactions.
+
+## Additional Considerations
+
+### Smart Property
+
+One of the core features that bitcoin protocol layers, including Mastercoin, Counterparty and various colored coins implementations, provide is the creation of coins or tokens that represent something else. Thus far, the items represented by protocol layer coins have been relegated to the digital world. Though we must consider that the bitcoin ecosystem is in its infancy, and the protocol layers even younger, it’s important to look forward to the future and consider how the approaches of different protocol implementations affect a properties interaction with the physical world. 
+
+The address model imposes resounding limitations due to the challenge in verifying transactions. Since address model coins aren’t “attached” to transaction outputs, the entire blockchain and internet access is, at a minimum, required for a smart object to verify ownership. This renders many smart object infeasible. For example, it’s not reasonable for smart door locks, smart cars, and smart phones to have these requirements - especially because internet connectivity is not universally available, cheap, or dependable. Another consideration is storage space. With the blockchain ever growing, it’s not feasible to create smart devices with enough storage space to store the blockchain for the indefinite future.
+
+### Thin clients 
+
+Since address model protocol layers require the entire blockchain to verify transactions, it’s not possible to develop a secure thin client like Electrum, Multibit, or mobile wallets.
+
+### Transparent P2SH and multisignature support
+
+By associating tokens with transaction outputs, the challenge that the Master Protocol has historically had with *uncommon* transaction inputs and outputs dissolves. Not only does this allow for transparent support of P2SH and multisignature inputs and outputs, but it allows the Master Protocol to support any future input and output types found in Bitcoin transactions. The alignment of the Master Protocol with the fundamental structure of the Bitcoin protocol allows the Master Protocol to take advantage of the advancements made in the Bitcoin network.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿The Master Protocol / Mastercoin Complete Specification
 =======================================================
 
-Version 0.4.5.9 Smart Property Crowdsale Edition
+Version 0.4.5.7 Smart Property Crowdsale Edition
 
 * JR Willett (https://github.com/dacoinminster and jr DOT willett AT gmail DOT com)
 * Maran Hidskes (https://github.com/maran)
@@ -60,7 +60,6 @@ Note that all transfers of value are still stored in the normal bitcoin block ch
 1. Version 0.4.5.6 released 19 Apr 2014 (SP crowdsale funds not locked)
 1. Version 0.4.5.7 released 2 May 2014 (lock down transaction decoding rules)
 1. Version 0.4.5.8 released 8 May 2014 (adjust output value requirements)
-1. Version 0.4.5.9 released 9 June 2014 (Added transaction type 5 Multi Send)
 
 * Pre-github versions of this document (prior to version 0.3.5 / previously 1.2) can be found at https://sites.google.com/site/2ndbtcwpaper/
 
@@ -187,21 +186,15 @@ This section defines the fields that are used to construct transaction messages.
 + Size: 32-bit unsigned integer, 4 bytes
 + Valid values: 0 to 4,294,967,295
 
-### Field: Integer-two byte
-+ Description: used as a multiplier or in other calculations
-+ Size: 16-bit unsigned integer, 2 bytes
-+ Valid values: 0 to 65535
-
 ### Field: Integer-one byte
 + Description: used as a multiplier or in other calculations
 + Size: 8-bit unsigned integer, 1 byte
 + Valid values: 0 to 255
 
-### Field: Boolean array-one byte
-+ Description: used for true/false flags
-+ Size: 8-bit boolean array, 1 byte
-+ Valid values: 0000 0000 to 1111 1111
-
+### Field: Integer-two byte
++ Description: used as a multiplier or in other calculations
++ Size: 16-bit unsigned integer, 2 bytes
++ Valid values: 0 to 65535
 
 ### Field: Listing identifier (future)
 + Description: the unique identifier assigned to each sale listing an a per address basis
@@ -283,7 +276,6 @@ This section defines the fields that are used to construct transaction messages.
 + To be added in future releases:
     *    2: [Restricted Send](#restricted-send)
     *    3: [Pay Dividends (Send All)](#pay-dividends-send-all)
-    *    5: [Multi Send](#transfer-coins-multi-send)
     *   10: [Mark an Address as Savings](#marking-an-address-as-savings)
     *   11: [Mark a Savings Address as Compromised](#marking-a-savings-address-as-compromised)
     *   12: [Mark an Address as Rate-Limited](#marking-an-address-as-rate-limited)
@@ -589,39 +581,6 @@ Note that attempts to participate in a closed crowdsale will result in no invest
 # Future Transactions
 
 The transactions below are still subject to revision and therefore are not included in deployments based on this version of the spec. 
-
-### Transfer Coins (Multi Send)
-
-Description: Transaction type 5 transfers coins in the specified currency from the sending address to one or more output addresses. This transaction can not be used to transfer bitcoins.
-
-The first recipient will be defined similarly to the recipient of a Simple Send, with the primary differences being that the address is explicitly stated and the quantity of coins transferred is calculated. The amount of coins sent is calculated by subtracting the dust threshold (currently 5640) from the amount of bitcoin sent to that address, and multiplying that value by 10 to the power of x, where x is specified by the sender.
-
-The bit-field following the data for the first recipient specifies whether the following recipients require the index and currency to be specified. If these bits are set, each recipient is specified by index, and is specified to receive a different currency. If both are cleared, each recipient will receive the currency that is sent to the first recipient, and each sequential recipient will correspond to sequential outputs. This is done to save space - the cost of specifying these is 9 bytes per recipient. By leaving these cleared, coins can be sent to recipients at the cost of 1 byte per additional recipient.
-
-The transaction is invalid if any of the following conditions is true:
-* the sending address has zero coins in its available balance for the specified currency identifier
-* the amount to transfer exceeds the number owned and available by the sending address
-* the specified currency identifier is non-existent
-* the specified currency identifier is 0 (bitcoin)
-
-A Multi send to a non-existent address will destroy the coins in question, just like it would with bitcoin.
-
-[Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
-
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
-
-1. [Transaction version](#field-transaction-version) = 0
-1. [Transaction type](#field-transaction-type) = 5
-1. [Currency identifier](#field-currency-identifier) = 1 for Mastercoin 
-1. [Output index](#field-integer-one-byte) = 0, indicating that the 0th output is the recipient
-1. [Magnitude to transfer](#field-integer-one-byte) = 8, when the value at output 0 is 5641, the total transferred is (5641 - 5640) * 10 ** 8 = 100,000,000 (1.00000000 MSC)
-1. [Flags](#field-boolean-array-one-byte):
-	* 0 = Cleared, indicating that all recipients will receive currency specified by first recipient.
-	* 1 = Cleared, indicating that sequential recipients correspond to sequential output indices starting from the index of the first recipient.
-	* 2-7 = Reserved
-1. [Magnitude to transfer](#field-integer-one-byte) = 5, when the value at output 1 is 6874, the total transferred is (6874 - 5640) * 10 ** 5 = 123,400,000 (1.23400000 MSC)
-
-Fields can be added as necessary for additional recipients.
 
 ## Transactions to Limit Funds (Theft Prevention)
 

--- a/README.md
+++ b/README.md
@@ -1308,3 +1308,17 @@ Since address model protocol layers require the entire blockchain to verify tran
 ### Transparent P2SH and multisignature support
 
 By associating tokens with transaction outputs, the challenge that the Master Protocol has historically had with *uncommon* transaction inputs and outputs dissolves. Not only does this allow for transparent support of P2SH and multisignature inputs and outputs, but it allows the Master Protocol to support any future input and output types found in Bitcoin transactions. The alignment of the Master Protocol with the fundamental structure of the Bitcoin protocol allows the Master Protocol to take advantage of the advancements made in the Bitcoin network.
+
+### The Exodus Address
+
+The Exodus address is iconic to the Master Protocol, being the address to which bitcoins were sent and from which Mastercoins were generated, and the address that defines the conception of Bitcoin protocol layers. Despite this the Mastercoin project has been criticized for requiring a bitcoin payment, albeit small, to the Exodus address for every single Master Protocol transaction.
+
+The challenge of recognizing Master Protocol transactions is ameliorated by requiring an output to the Exodus address. It allows Master Protocol implementations to check only a relatively small set of transactions - those which have an output to the Exodus address - rather than having to check every single Bitcoin transaction for the inclusion of Master Protocol data.
+
+Under the output model, the Master Protocol would be able to absolve the requirement that users send an output to the Exodus address. This is due to the ability to determine the validity of a Master Protocol transaction with only it's chain of ownership, rather than requiring the complete blockchain.
+
+The transition to an output model and removal of the requirement that Master Protocol transactions have an output to the Exodus address:
+
+- Eliminates controversial "tax" to the Exodus address.
+- Decreases data footprint of Master Protocol transactions.
+- Decreases total cost of Master Protocol transactions.

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ A Multi send to a non-existent address will destroy the coins in question, just 
 
 [Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
 
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
+Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only 12 bytes are needed. The data stored is:
 
 1. [Transaction version](#field-transaction-version) = 0
 1. [Transaction type](#field-transaction-type) = 5


### PR DESCRIPTION
Appendix F includes details on the proposal for the Master Protocol to transition to an output model.

The section is incomplete and it's not my intention that this be merged immediately. I would like to use it as a place to discuss a potential plan for the transition to an output model, and to detail the benefits and mechanisms by which an output model would function. Note, this is section doesn't answer "should we transition," but what the transition would look like if it were to take place.

Notable items include:
- Proposal for drastic decrease in Master Protocol transaction costs (over 50% reduction)
- Atomic Meta DEx (which to my knowledge hasn't been done before with an output model)
- Notes on the use of Mastercoin in an output model
- Thin clients
- P2SH and multisig support
- Proposal to remove the required output to the Exodus address
- Proposal for cross protocol atomic swaps (interoperability with other protocols!!)

Relevant sources: 
- https://github.com/mastercoin-MSC/spec/issues/192 Reduce transaction costs
- https://github.com/mastercoin-MSC/spec/issues/189 Should we migrate to output model?
- https://github.com/mastercoin-MSC/spec/pull/233 Pull request for relevant whitepaper
- http://www.reddit.com/r/mastercoin/comments/2bz8ub/how_the_monetization_of_mastercoin_will_lead_to/ A post on the necessity for Mastercoin to change directions or face irrelevancy.
