### PR TITLE
Class D transaction type

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ A Multi send to a non-existent address will destroy the coins in question, just 
 
 [Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
 
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only 12 bytes are needed. The data stored is:
+Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
 
 1. [Transaction version](#field-transaction-version) = 0
 1. [Transaction type](#field-transaction-type) = 5

--- a/README.md
+++ b/README.md
@@ -1191,7 +1191,7 @@ Total perceived cost ~$0.14 per transaction.
 
 Each multisig output in a Class B transaction may contain two Master Protocol packets of 30 bytes each.  Thus we can infer (again at 650 USD per BTC) that for every 60 bytes, we increase perceived transaction cost by ~$0.08.
 
-Class D transactions may contain one Master Protocol of 30 bytes. We can infer (again at 650 USD per BTC) that for every 60 bytes of additional data, we increase perceived transaction by ~$0.08.
+Class D transactions may contain one Master Protocol of 30 bytes. We can infer (again at 650 USD per BTC) that for every 60 bytes of additional data, we increase perceived transaction cost by ~$0.08.
 
 The term 'perceived' cost has been applied as the Master Protocol transaction model does not 'burn' (destroy) these outputs, but rather they are redeemable by the various participants of the transaction (with the exception of the Class A data address, hence its deprecation).  
 

--- a/README.md
+++ b/README.md
@@ -1178,13 +1178,13 @@ Total perceived cost ~$0.18 per transaction.
 **Class B**  
 0.00006 ($0.04) - Exodus Address Output  
 0.00006 ($0.04) - Reference Address Output  
-0.00012 ($0.7) - Per Multisig Output  
+0.00012 ($0.07) - Per Multisig Output  
 0.0001 ($0.07) - Bitcoin Transaction Fee  
   
 Total perceived cost ~$0.22 per transaction.  
 
 **Class D**  
-0.00012 ($0.7) - Multisig Output  
+0.00012 ($0.07) - Multisig Output  
 0.0001 ($0.07) - Bitcoin Transaction Fee  
   
 Total perceived cost ~$0.14 per transaction.  

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ﻿The Master Protocol / Mastercoin Complete Specification
 =======================================================
 
-Version 0.4.5.9 Smart Property Crowdsale Edition
+Version 0.4.5.7 Smart Property Crowdsale Edition
 
 * JR Willett (https://github.com/dacoinminster and jr DOT willett AT gmail DOT com)
 * Maran Hidskes (https://github.com/maran)
@@ -60,7 +60,6 @@ Note that all transfers of value are still stored in the normal bitcoin block ch
 1. Version 0.4.5.6 released 19 Apr 2014 (SP crowdsale funds not locked)
 1. Version 0.4.5.7 released 2 May 2014 (lock down transaction decoding rules)
 1. Version 0.4.5.8 released 8 May 2014 (adjust output value requirements)
-1. Version 0.4.5.9 released 9 June 2014 (Added transaction type 5 Multi Send)
 
 * Pre-github versions of this document (prior to version 0.3.5 / previously 1.2) can be found at https://sites.google.com/site/2ndbtcwpaper/
 
@@ -187,21 +186,15 @@ This section defines the fields that are used to construct transaction messages.
 + Size: 32-bit unsigned integer, 4 bytes
 + Valid values: 0 to 4,294,967,295
 
-### Field: Integer-two byte
-+ Description: used as a multiplier or in other calculations
-+ Size: 16-bit unsigned integer, 2 bytes
-+ Valid values: 0 to 65535
-
 ### Field: Integer-one byte
 + Description: used as a multiplier or in other calculations
 + Size: 8-bit unsigned integer, 1 byte
 + Valid values: 0 to 255
 
-### Field: Boolean array-one byte
-+ Description: used for true/false flags
-+ Size: 8-bit boolean array, 1 byte
-+ Valid values: 0000 0000 to 1111 1111
-
+### Field: Integer-two byte
++ Description: used as a multiplier or in other calculations
++ Size: 16-bit unsigned integer, 2 bytes
++ Valid values: 0 to 65535
 
 ### Field: Listing identifier (future)
 + Description: the unique identifier assigned to each sale listing an a per address basis
@@ -283,7 +276,6 @@ This section defines the fields that are used to construct transaction messages.
 + To be added in future releases:
     *    2: [Restricted Send](#restricted-send)
     *    3: [Pay Dividends (Send All)](#pay-dividends-send-all)
-    *    5: [Multi Send](#transfer-coins-multi-send)
     *   10: [Mark an Address as Savings](#marking-an-address-as-savings)
     *   11: [Mark a Savings Address as Compromised](#marking-a-savings-address-as-compromised)
     *   12: [Mark an Address as Rate-Limited](#marking-an-address-as-rate-limited)
@@ -589,39 +581,6 @@ Note that attempts to participate in a closed crowdsale will result in no invest
 # Future Transactions
 
 The transactions below are still subject to revision and therefore are not included in deployments based on this version of the spec. 
-
-### Transfer Coins (Multi Send)
-
-Description: Transaction type 5 transfers coins in the specified currency from the sending address to one or more output addresses. This transaction can not be used to transfer bitcoins.
-
-The first recipient will be defined similarly to the recipient of a Simple Send, with the primary differences being that the address is explicitly stated and the quantity of coins transferred is calculated. The amount of coins sent is calculated by subtracting the dust threshold (currently 5640) from the amount of bitcoin sent to that address, and multiplying that value by 10 to the power of x, where x is specified by the sender.
-
-The bit-field following the data for the first recipient specifies whether the following recipients require the index and currency to be specified. If these bits are set, each recipient is specified by index, and is specified to receive a different currency. If both are cleared, each recipient will receive the currency that is sent to the first recipient, and each sequential recipient will correspond to sequential outputs. This is done to save space - the cost of specifying these is 9 bytes per recipient. By leaving these cleared, coins can be sent to recipients at the cost of 1 byte per additional recipient.
-
-The transaction is invalid if any of the following conditions is true:
-* the sending address has zero coins in its available balance for the specified currency identifier
-* the amount to transfer exceeds the number owned and available by the sending address
-* the specified currency identifier is non-existent
-* the specified currency identifier is 0 (bitcoin)
-
-A Multi send to a non-existent address will destroy the coins in question, just like it would with bitcoin.
-
-[Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
-
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
-
-1. [Transaction version](#field-transaction-version) = 0
-1. [Transaction type](#field-transaction-type) = 5
-1. [Currency identifier](#field-currency-identifier) = 1 for Mastercoin 
-1. [Output index](#field-integer-one-byte) = 0, indicating that the 0th output is the recipient
-1. [Magnitude to transfer](#field-integer-one-byte) = 8, when the value at output 0 is 5641, the total transferred is (5641 - 5640) * 10 ** 8 = 100,000,000 (1.00000000 MSC)
-1. [Flags](#field-boolean-array-one-byte):
-	* 0 = Cleared, indicating that all recipients will receive currency specified by first recipient.
-	* 1 = Cleared, indicating that sequential recipients correspond to sequential output indices starting from the index of the first recipient.
-	* 2-7 = Reserved
-1. [Magnitude to transfer](#field-integer-one-byte) = 5, when the value at output 1 is 6874, the total transferred is (6874 - 5640) * 10 ** 5 = 123,400,000 (1.23400000 MSC)
-
-Fields can be added as necessary for additional recipients.
 
 ## Transactions to Limit Funds (Theft Prevention)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿The Master Protocol / Mastercoin Complete Specification
+The Master Protocol / Mastercoin Complete Specification
 =======================================================
 
 Version 0.4.5.9 Smart Property Crowdsale Edition
@@ -1085,9 +1085,21 @@ Further:
 * Only pay-to-pubkey-hash outputs will be considered for the reference address
 * Only multisig outputs will be considered for the data packets
 * If there are multiple outputs remaining, the first output to the sending address (if such an output exists) will be ignored as change
-* The reference address will be determined by the remaining output with the highest vout index  
+* The reference address will be determined by the remaining output with the highest vout index 
 
+## Class D transactions (also known as the modified 'multisig' method) 
 
+Class D transactions attempt to optimize Class B transactions by:
+
+- Reducing the cost of Master Protocol transactions that require less than 31 bytes of data by 0.00012 BTC.
+- Increasing the quantity of bytes available in which to encode Master Protocol data for transactions that require more than 30 bytes of data by  30 bytes, at the same cost as Class B transactions.
+- Decreasing the potential for UXTO bloat, by increasing the chance that multisig data outputs will be spent.
+- Eliminating the "Exodus address tax."
+- Minimizing the data footprint of Master Protocol transactions.
+
+By deprecating the outputs that a Class B transaction requires to the Exodus and Reference addresses, we can include the respective public keys in a 1-of-3 multisig output. The first public key should be the intended recipient, the second the public key of the Exodus address, and the third a Master Protocol data packet. In this manner, the cost of a Simple Send transaction can be reduced from 0.00034 BTC to 0.00022 BTC, and can be performed with a single transaction output.
+
+For Master Protocol transactions that require more than 30 bytes of embedded data, additional multisig outputs can be added as necessary following the same guidelines as Class B transactions.
 
 # Appendix B – Regulatory and Legal Compliance - Know Your Jurisdiction
 
@@ -1171,8 +1183,16 @@ Total perceived cost ~$0.18 per transaction.
   
 Total perceived cost ~$0.22 per transaction.  
 
-Each multisig output in a Class B transaction may contain two Master Protocol packets of 30 bytes each.  Thus we can infer (again at 650 USD per BTC) that for every 60 bytes, we increase perceived transaction cost by ~$0.08.
+**Class D**  
+0.00012 ($0.7) - Multisig Output  
+0.0001 ($0.07) - Bitcoin Transaction Fee  
   
+Total perceived cost ~$0.14 per transaction.  
+
+Each multisig output in a Class B transaction may contain two Master Protocol packets of 30 bytes each.  Thus we can infer (again at 650 USD per BTC) that for every 60 bytes, we increase perceived transaction cost by ~$0.08.
+
+Class D transactions may contain one Master Protocol of 30 bytes. We can infer (again at 650 USD per BTC) that for every 60 bytes of additional data, we increase perceived transaction by ~$0.08.
+
 The term 'perceived' cost has been applied as the Master Protocol transaction model does not 'burn' (destroy) these outputs, but rather they are redeemable by the various participants of the transaction (with the exception of the Class A data address, hence its deprecation).  
 
 In a class A transaction (note class A allows simple send only):

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ A Multi send to a non-existent address will destroy the coins in question, just 
 
 [Future: Note that if the transfer comes from an address which has been marked as “Savings”, there is a time window in which the transfer can be undone.]
 
-Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only xx bytes are needed. The data stored is:
+Say you want to transfer 1 Mastercoin to another address, and 1.234 Mastercoin to another address.. Only 12 bytes are needed. The data stored is:
 
 1. [Transaction version](#field-transaction-version) = 0
 1. [Transaction type](#field-transaction-type) = 5


### PR DESCRIPTION
Class D transactions include the reference public key and the public key of the Exodus address in a multisig output. A third public key in the multisig output may included embedded Master Protocol data.

The goal of the Class D transaction is to optimize Class B transactions by reducing size, cost, chance that multisig outputs will remain unspent, and in some cases, increase the amount of bytes available to embed MP data without increasing cost (over Class B transactions, that is).

Relevant: Find a clever trick to lower the cost of transactions, https://github.com/mastercoin-MSC/spec/issues/192
