### PR TITLE
Smart Property Administration

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,34 @@ This section defines the fields that are used to construct transaction messages.
 + Inter-dependencies: [Transaction type](#field-transaction-type)
 + Valid values: 0 to 65535
 
+### Field: Address Reference
++ Description: RIPEMD-160 hash of a bitcoin wallet public address
++ Size: 20bytes
++ Valid values: any 20byte value
+
+### Field: Transaction Reference
++ Description: hash of a bitcoin transaction
++ Size: 32bytes
++ Valid values: any 32byte value
+
+### Field: Electorate Type
++ Description: The type of [Electorate](#electorates) described by the rest of the tranaction
++ Size: 8-bit unsigned integer, 1 byte
++ Inter-dependencies: [Electorate Definition](#field-electorate-definition)
++ Current Valid values:
+    *    1: [Explicit Address Electorate](#explicit-address-electorate)
+    *    2: [Token Ownership Electorate](#token-ownership-electorate)
+
+### Field: Electorate Definition
++ Description: the concrete definition of an [Electorate](#electorates)
++ Size: Variable length depending on the [Electorate Type](#field-electorate-type)
++ Required/optional: Required
++ Inter-dependencies: [Electorate Type](#field-electorate-type)
++ Valid values (by [Electorate Type](#field-electorate-type)):
+    *    1: [Address Reference](#field-address-reference) that serves as the [Explicit Address Electorate](#explicit-address-electorate)
+    *    2: [Currency identifier](#field-currency_identifier) used to define membership in a [Token Ownership Electorate](#token-ownership-electorate)
+
+
 # Transaction Definitions
 
 Each transaction definition has its own version number to enable support for changes to each transaction definition. Up thru version 0.3.5 of this spec, the Transaction type field was a 4 byte integer. Since there were only 17 transactions identified, the upper 3 bytes of the field had a value of 0. For all spec versions starting with 0.4, the first field in each transaction message is the 2 byte version number, with an initial value of 0 and the Transaction type field is a 2 byte integer. So, each client must examine the first two bytes of the transaction message to determine how to parse the remainder of the message. If the value is 0, then the message is in the format specified in version 0.3.5 of this spec. If the value is at least 1, then the message is in the format associated with that version number.
@@ -872,7 +900,7 @@ Say you wanted to "approve" the action broadcast in transaction 9595c9df90075148
 | Transaction version |[Transaction version](#field-transaction-version) | 0 |
 | Transaction type | [Transaction type](#field-transaction-type) | 71| 
 | Property ID | [Currency identifier](#field-currency-identifier) | 9 |
-| Transaction ID | [Integer-thirty two byte](#field-integer-thirty-two-byte) | 9595c9df90075148eb06860365df33584b75bff782a510c6cd4883a419833d50 |
+| Transaction ID | [Transaction Reference](#field-transaction-reference) | 9595c9df90075148eb06860365df33584b75bff782a510c6cd4883a419833d50 |
 | Vote | [String null-terminated](#field-string-255-byte-null-terminated) | "approve\0” (5 bytes) |
 | Memo | [String null-terminated](#field-string-255-byte-null-terminated) | "I think this is swell\0” (22 bytes) |
 


### PR DESCRIPTION
This proposal is for a unified (and backwards compatible) system of Smart Property Administration.  At the moment, we don't have much need for Smart Property Administration as the only post-broadcast action which exists for Smart Properties is the premature close of a crowdsale.   However, with the sister PR #243 we are (potentially) introducing a Smart Property that will have critical post-broadcast actions and as such we need a system to allow Administration to change hands over time and secure itself against threats like compromised private keys.  Without some formal Administration system, even long-running crowdsales run an increasing risk of being compromised.

The system is meant to propose a few starting paradigms: one that provides backwards compatibility so that administration rules can be applied universally and retroactively and another that provides basic distributed administration to provide robustness against attacks which compromise some of the keys.  However, in the future, more paradigms are likely to appear.

There is one legacy "expectation" that (depending on interpretation) is not currently maintained explicitly: the ability to freely transact in a given Smart Property in perpetuity.  It is possible, that the current implicit Administration of an existing Smart Property could surrender said Smart Property to a new Administration that imposes approval rules on simple sends or Dex messages.  In this way, the implied contract of the original SP could be considered broken as tokens would no longer be transferable without approval.  As a hedge against that, it may be necessary to impose implicit limitations on the Administration for existing SPs, particularly that their approval rules for basic trade are immutable regardless of future Administration changes.

Note: while their is mention of "voting" in the proposal, this is not meant to supplant or replace any previously discussed spec changes for conducting votes on the chain.  While this system may be sufficient for such a need with the addition of a manual "call for vote" that contains its own approval rules, its primary focus should remain the Administration of Smart Property. 
