### PR TITLE
P2sh support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,9 +1193,9 @@ NOTE: Class A transactions are restricted to the ‘simple send’ transaction t
 
 ## Class B transactions (also known as the ‘multisig’ method) 
 
-Class B transactions attempt to address the UTXO ‘bloat’ issue by storing data in the blockchain by utilizing ‘1-of-n’ multisignature outputs where one of the signatories should be the sender.   
+Class B transactions attempt to address the UTXO ‘bloat’ issue by storing data in the blockchain by utilizing ‘1-of-n’ multisignature outputs where one of the signatories is the sender or another public key address the sender has designated.   
 
-By adopting a ‘1-of-n’ approach (credit Tachikoma @ bitcointalk) we can increase n to the number of packets (public keys) needed to store the transaction data while maintaining the ability of the sender to redeem the output.  
+By adopting a ‘1-of-n’ approach (credit Tachikoma @ bitcointalk) we can increase n to the number of packets (public keys) needed to store the transaction data while maintaining the ability of the sender or their designated party to redeem the output.  
 
 NOTE: The reference client currently supports a maximum value of 3 for n.  As one signatory should be the sender for redemption purposes, there is a current limit of 2 data packets per output.  A number of multisig outputs can be combined to increase the space available for transaction data as required.  On decoding all Mastercoin packets from all multisig outputs are ordered via their sequence number and evaluated as a continuous data stream. 
 
@@ -1228,7 +1228,7 @@ These compressed public key 'packets' can then be included in one or multiple OP
 * Has a single or the largest pay-to-pubkey-hash or pay-to-script-hash input with a valid signature to designate the sending address
 * Has an output for the recipient address (the 'reference' address)
 * Has an output for the exodus address
-* Has one or more n-of-m OP_CHECKMULTISIG outputs each containing at least two public keys whereby the first should be the sender's public key, the second must be Mastercoin 'data package n' and the third may be 'data package n+1'
+* Has one or more n-of-m OP_CHECKMULTISIG outputs each containing at least two public keys whereby the first should be a valid public key address designated by the sender which may be used to reclaim the bitcoin assigned to the output, the second must be Mastercoin 'data package n' and the third may be 'data package n+1'
 * Mastercoin 'data packages' appear in order by their sequence number 
 * Additional outputs are permitted 
 


### PR DESCRIPTION
Pay-to-script-hash addresses represent some of the better security options for bitcoin addresses.  With bitcoin core talking about extending the features allowed in the hashed script, these addresses will become increasingly powerful.

From the protocol's perspective these addresses may as well be opaque addresses like pubkey-hashes.  Currently, this would afford users of the protocol the ability to create M-of-N multisig addresses to hold MASTER protocol tokens.

The one caveat is that our Class B transactions use 1-of-N outputs to redeem the bitcoin spent in the service of the protocol (Note: multisig outputs are distinct from p2sh addresses which utilize multisig).  OP_CHECKMULTISIG only accepts public key addresses.  We are currently bridging support for pubkey-hash addresses IFF the address is in our local wallet.  This PR proposes to allow the constructor/sender of the transaction to designate a public key address to redeem outputs with so that in the case of an address flavor that isn't compatible with multisig outputs the bitcoin are not lost. 

this is paired with a code PR mastercoin-MSC/mastercore#102
