### PR TITLE
Change issuer on record

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ This section defines the fields that are used to construct transaction messages.
     *   54: [Create a Managed Property with Grants and Revocations](#new-property-with-managed-number-of-tokens)
     *   55: [Grant Property Tokens](#granting-tokens-for-a-managed-property)
     *   56: [Revoke Property Tokens](#revoking-tokens-for-a-managed-property)
-    *   70: [Change Property Issuer on Record](#change-issuer=on-record-for-a-property)
+    *   70: [Change Property Issuer on Record](#change-issuer-on-record-for-a-property)
 
 + To be added in future releases:
     *    2: [Restricted Send](#restricted-send)
@@ -854,9 +854,9 @@ Say that your project is finished and you want to start burning tokens in exchan
 ## Smart Property Administration
 
 The Master Protocol provides support for a limited number of administrative tasks regarding Smart Properties. Administrative actions are permitted only by the Issuer on Record (issuer) which is implicitly recognized as the address which originally broadcast the transaction that reserved the currency ID of the Smart Property in question until explicitly changed.  The transactions which create an implicit Issuer on Record are:
-    *   50: [Create a Property with fixed number of tokens](#new-property-creation-with-fixed-number-of-tokens)
-    *   51: [Create a Property via Crowdsale with Variable number of Tokens](#new-property-creation-via-crowdsale-with-variable-number-of-tokens)
-    *   54: [Create a Managed Property with Grants and Revocations](#new-property-with-managed-number-of-tokens)
+* 50: [Create a Property with fixed number of tokens](#new-property-creation-with-fixed-number-of-tokens)
+* 51: [Create a Property via Crowdsale with Variable number of Tokens](#new-property-creation-via-crowdsale-with-variable-number-of-tokens)
+* 54: [Create a Managed Property with Grants and Revocations](#new-property-with-managed-number-of-tokens)
 
 ### Change Issuer on Record for a Smart Property
 


### PR DESCRIPTION
This is a pulled back version of Smart Property Administration allowing for the rotation of issuer address for long lasting crowdsales and manually issued properties.

These properties live long enough that good security practices would require the address which possesses administrative power to rotate and stay fresh.

This does not preclude a future more fully featured SP administration layer, as any system would necessarily need to allow a change of issuer. 

NOTE: there is one omission in the revoke manual issuance transaction where the wording was not changed to respect the issuer on record.  This is because PR #256 removes that clause entirely and I did not want to cause merge conflicts
