### PR TITLE
Optionally restrict a token to a set of addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ Any referenced addresses are removed from the list.  Note that as with the previ
 
 ## Transactions to Limit Funds (Theft Prevention)
 
-The Master Protocol defines some transactions which effectively lock funds from being spent quickly, making theft of a "savings" wallet much more difficult, even if that wallet is online. 
+The Master Protocol defines some transactions which effectively lock funds from being spent quickly, making theft of a "savings" wallet much more difficult, even if that wallet is online.
 
 ### Marking an Address as “Savings”
 


### PR DESCRIPTION
Numerous projects want this feature to try to comply with KYC/AML laws. This is my first cut at creating a list of addresses, and referring to the list when creating a property such that the property is restricted to being used only by addresses on the list.
