### PR TITLE
Update AssetIssuanceStandard.md

### DIFF
--- a/AssetIssuanceStandard.md
+++ b/AssetIssuanceStandard.md
@@ -40,9 +40,9 @@ Assets definitions use [JSON](http://www.json.org) format with UTF-8 encoding. W
 	"format": "* dollars",
 	"format_1": "1 dollar",
 	
-	"mastercoin_id": "123456",
-	"coinprism_sources": ["2MyvmsxoCxsnzPapDnK7ZcMxWjU3hqLZkpX"],
-	"coincolors_id": "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6"
+	"meta_id": "123456",
+	"meta_source": "mastercoin|coloredcoin|futureproof",
+	"source_data": ["2MyvmsxoCxsnzPapDnK7ZcMxWjU3hqLZkpX"]
 }
 ```
 


### PR DESCRIPTION
I've proposed the following change:
This specification mentions 3 additional pieces of data:

```
"mastercoin_id": "123456",
"coinprism_sources": ["2MyvmsxoCxsnzPapDnK7ZcMxWjU3hqLZkpX"],
"coincolors_id": "f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6"
```

I think we can safely assume that an asset that is issued is usually done using one protocol. I won't issue a BobsIceCreamToken on both mastercoin as well as Coloredcoin or CounterParty (or for that matter any future meta-framework).

Therefor there is a meta_id (instead of colorcoinid and/or mastercoinid).
meta_source is hopefully self-explanatory.
the coinprism_sources field, I propose be renamed to source_data that any of the other frameworks (mastercoin, and yes coinprism too) can use.

The number of fields remains the same and this is backwards compatible with any thing that already might be built.
