### PR TITLE
Gradle: Reflect that Spec is no longer in README

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,23 +18,17 @@ def buildDocDir = file('build/doc')
 asciidoctor {
   sourceDir file("$projectDir")
   sources {
-    include 'README.adoc'
+    include 'OmniSpecification.adoc'
   }
   outputDir  buildDocDir
-  doLast {
-    file("${outputDir}/README.html").renameTo("${outputDir}/Omni-Specification.html")
-  }
 }
 
 asciidoctorPdf {
   sourceDir file("$projectDir")
   sources {
-    include 'README.adoc'
+    include 'OmniSpecification.adoc'
   }
   outputDir  buildDocDir
-  doLast {
-    file("${outputDir}/README.pdf").renameTo("${outputDir}/Omni-Specification.pdf")
-  }
 }
 
 task renderOmniSpecification(dependsOn: [asciidoctor, asciidoctorPdf])


### PR DESCRIPTION
The Github Actions to render HTML and PDF are still rendering `README.adoc`. This PR changes `build.gradle` to render `OmniSpecification.adoc`.